### PR TITLE
Use absolute path to __file__

### DIFF
--- a/pylmod/__init__.py
+++ b/pylmod/__init__.py
@@ -8,21 +8,25 @@ from pylmod.client import Client
 from pylmod.gradebook import GradeBook
 from pylmod.membership import Membership
 
-# pylint: disable=no-member
-try:
-    DIST = get_distribution('pylmod')
-    # Normalize case for Windows systems
-    DIST_LOC = os.path.normcase(DIST.location)
-    HERE = os.path.normcase(__file__)
-    if not HERE.startswith(
-            os.path.join(DIST_LOC, 'pylmod')
-    ):  # pragma: no cover
-        # not installed, but there is another version that *is*
-        raise DistributionNotFound
-except DistributionNotFound:  # pragma: no cover
-    __version__ = 'Please install this project with setup.py'
-else:
-    __version__ = DIST.version
 
+def _get_version():
+    """Grab version from pkg_resources"""
+    # pylint: disable=no-member
+    try:
+        dist = get_distribution(__project__)
+        # Normalize case for Windows systems
+        dist_loc = os.path.normcase(dist.location)
+        here = os.path.normcase(os.path.abspath(__file__))
+        if not here.startswith(
+                os.path.join(dist_loc, __project__)
+        ):
+            # not installed, but there is another version that *is*
+            raise DistributionNotFound
+    except DistributionNotFound:
+        return 'Please install this project with setup.py'
+    else:
+        return dist.version
 
 __all__ = ['Client', 'GradeBook', 'Membership']
+__project__ = 'pylmod'
+__version__ = _get_version()

--- a/pylmod/tests/test_module.py
+++ b/pylmod/tests/test_module.py
@@ -4,6 +4,7 @@ Testing of the module level stuff itself
 """
 import unittest
 
+import mock
 import semantic_version
 
 
@@ -30,3 +31,23 @@ class TestModule(unittest.TestCase):
             ['Client', 'GradeBook', 'Membership'],
             pylmod.__all__
         )
+
+    def test_bad_version(self):
+        """Verify bad version handling"""
+        from pkg_resources import DistributionNotFound
+        from pylmod import _get_version
+
+        error_string = 'Please install this project with setup.py'
+
+        with mock.patch('pylmod.get_distribution') as mock_distribution:
+            # Test with distribution not found:
+            mock_distribution.side_effect = DistributionNotFound()
+            self.assertEqual(_get_version(), error_string)
+
+        # Test with loc path not matching
+        with mock.patch('os.path.abspath') as mock_path:
+            mock_path.return_value = 'not/where/we/are'
+            self.assertEqual(_get_version(), error_string)
+            # Bonus regression test to make sure we are calling
+            # abspath.
+            self.assertTrue(mock_path.called)


### PR DESCRIPTION
This should fix the readthedocs bug #25. I don't have enough SO rep to comment, but the code didn't properly path \__file\__.  This adds that and makes the code look a little nicer. See http://pylmod.readthedocs.org/en/feature-cg-apidoc_debug/ for this PR cherry-picked onto @pwilkins api docs PR and note the version is correct