### PR TITLE
Remove test for local version matching

### DIFF
--- a/pylmod/__init__.py
+++ b/pylmod/__init__.py
@@ -1,7 +1,6 @@
 """
 PyLmod is a module that implements MIT Learning Modules API in Python
 """
-import os.path
 from pkg_resources import get_distribution, DistributionNotFound
 
 from pylmod.gradebook import GradeBook
@@ -13,14 +12,6 @@ def _get_version():
     # pylint: disable=no-member
     try:
         dist = get_distribution(__project__)
-        # Normalize case for Windows systems
-        dist_loc = os.path.normcase(dist.location)
-        here = os.path.normcase(os.path.abspath(__file__))
-        if not here.startswith(
-                os.path.join(dist_loc, __project__)
-        ):
-            # not installed, but there is another version that *is*
-            raise DistributionNotFound
     except DistributionNotFound:
         return 'Please install this project with setup.py'
     else:

--- a/pylmod/tests/test_module.py
+++ b/pylmod/tests/test_module.py
@@ -43,11 +43,3 @@ class TestModule(unittest.TestCase):
             # Test with distribution not found:
             mock_distribution.side_effect = DistributionNotFound()
             self.assertEqual(_get_version(), error_string)
-
-        # Test with loc path not matching
-        with mock.patch('os.path.abspath') as mock_path:
-            mock_path.return_value = 'not/where/we/are'
-            self.assertEqual(_get_version(), error_string)
-            # Bonus regression test to make sure we are calling
-            # abspath.
-            self.assertTrue(mock_path.called)


### PR DESCRIPTION
There is only one known use case that you would care that the local
version is different than the pkg_resource distribution version. This
would only occur if you were in the pylmod directory and using python
from there. In this case you would get the globally installed version
instead of the checked out version after this commit.

On the other hand, readthedocs.org does exactly this (and gets the
wrong version), and it is much more likely that we would forget to
update the version in multiple places (i.e. docs/conf.py and setup.py)
so we have chosen to accept the narrower error case.