### PR TITLE
Handle unmatched gradebook students better #47

### DIFF
--- a/pylmod/gradebook.py
+++ b/pylmod/gradebook.py
@@ -932,6 +932,7 @@ class GradeBook(Base):
                     'Error in spreadsheet2gradebook: cannot find '
                     'student id for email="%s"\n', email
                 )
+                continue
             for field in row.keys():
                 if field in non_assignment_fields:
                     continue

--- a/pylmod/tests/test_gradebook.py
+++ b/pylmod/tests/test_gradebook.py
@@ -179,7 +179,8 @@ class TestGradebook(BaseTest):
         """Get a list of spreadsheet rows as dictionaries
 
         Get a list of spreadsheet row values to test submitting
-        grades in a spreadsheet to the LMod web service.
+        grades in a spreadsheet to the LMod web service. Only
+        grades with sid not equal to none are valid.
 
         Args:
             approve_grades (boolean): list of spreadsheet rows as
@@ -194,11 +195,6 @@ class TestGradebook(BaseTest):
                  'mode': 2,
                  'numericGradeValue': 2.2,
                  'studentId': 1},
-                {'assignmentId': 1,
-                 'isGradeApproved': approve_grades,
-                 'mode': 2,
-                 'numericGradeValue': 1.1,
-                 'studentId': None},
         ]
 
     def _register_get_gradebook(self, send_data=True):


### PR DESCRIPTION
Hi 

In this PR I added a continue statement to check of student Id is not available.
Now **grade_array** has only grades with student id not equal to none.

fixes https://github.com/mitodl/PyLmod/issues/47
cc @carsongee @pdpinch 
