### PR TITLE
Add autospec=True to mock object creation

### DIFF
--- a/pylmod/tests/test_gradebook.py
+++ b/pylmod/tests/test_gradebook.py
@@ -805,7 +805,11 @@ class TestGradebook(BaseTest):
             ])
         )
 
-    @mock.patch.object(GradeBook, '_spreadsheet2gradebook_multi')
+    @mock.patch.object(
+        GradeBook,
+        '_spreadsheet2gradebook_multi',
+        autospec=True,
+    )
     @mock.patch('csv.DictReader')
     def test_spreadshee2gradebook(self, csv_patch, multi_patch):
         """Do a simple test of the spreadsheet to gradebook public method"""
@@ -820,33 +824,31 @@ class TestGradebook(BaseTest):
         with tempfile.NamedTemporaryFile(delete=True) as temp_file:
             gradebook.spreadsheet2gradebook(temp_file.name)
             called_with = multi_patch.call_args
-            csv_patch.assert_called_once()
-            self.assertEqual(called_with[0][1], email_field)
-            self.assertEqual(called_with[0][2], non_assignment_fields)
-
+            assert csv_patch.call_count == 1
+            self.assertEqual(called_with[0][2], email_field)
+            self.assertEqual(called_with[0][3], non_assignment_fields)
         # Test with tmp file handle, approve_grades=False
         with tempfile.NamedTemporaryFile(delete=True) as temp_file:
             gradebook.spreadsheet2gradebook(temp_file.name,
                                             approve_grades=False)
             called_with = multi_patch.call_args
-            csv_patch.assert_called_once()
-            self.assertEqual(called_with[0][1], email_field)
-            self.assertEqual(called_with[0][2], non_assignment_fields)
-
+            assert csv_patch.call_count == 2
+            self.assertEqual(called_with[0][2], email_field)
+            self.assertEqual(called_with[0][3], non_assignment_fields)
         # Test with tmp file handle, approve_grades=True
         with tempfile.NamedTemporaryFile(delete=True) as temp_file:
             gradebook.spreadsheet2gradebook(temp_file.name,
                                             approve_grades=True)
             called_with = multi_patch.call_args
-            csv_patch.assert_called_once()
-            self.assertEqual(called_with[0][1], email_field)
-            self.assertEqual(called_with[0][2], non_assignment_fields)
+            assert csv_patch.call_count == 3
+            self.assertEqual(called_with[0][2], email_field)
+            self.assertEqual(called_with[0][3], non_assignment_fields)
 
         # Test with patched csvReader and named e-mail field
         alternate_email_field = 'stuff'
         gradebook.spreadsheet2gradebook(csv_patch, alternate_email_field)
         non_assignment_fields.append(alternate_email_field)
         called_with = multi_patch.call_args
-        csv_patch.assert_called_once()
-        self.assertEqual(called_with[0][1], alternate_email_field)
-        self.assertEqual(called_with[0][2], non_assignment_fields)
+        assert csv_patch.call_count == 4
+        self.assertEqual(called_with[0][2], alternate_email_field)
+        self.assertEqual(called_with[0][3], non_assignment_fields)


### PR DESCRIPTION
Mock has a switch that ensures you call only valid methods on the mock object.  The default behavior allows you to call fictitious methods that return ``True``. This code change enforces the rule to call only valid object methods.

Our existing code has calls to ``mock_object.assert_called_once()`` which looks like it tests the number of times the object is called, but actually just returns ``True``.  Always.  If you write your tests after you write your code, this "assert" seems to confirm that something is tested, but it doesn't do anything other than return ``True``.  More recent versions of the Mock package prevent this by default, and return an error when this sort of thing is encountered.

@pdpinch 