### PR TITLE
Added support for max_pts and normalize columns in spreadsheet2gradebook

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ README = open('README.rst').read()
 
 setup(
     name='pylmod',
-    version='0.1.0',
+    version='0.2.0',
     license='BSD',
     author='MIT ODL Engineering',
     author_email='odl-engineering@mit.edu',

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -7,3 +7,5 @@ pytest-cache>=1.0,
 httpretty>=0.8.3,
 semantic_version>=2.3.1
 mock>=1.0.1
+ddt==1.0.1
+


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #53 

#### What's this PR do?
If a column named `max_pts` or `normalize` exists in the spreadsheet and a new flag `use_max_points_column` is set to True, and if normalize is `0` (indicating not already normalized), pass the value from `max_pts` to the assignment creation POST.

#### Where should the reviewer start?
pylmod/gradebook.py

#### How should this be manually tested?
I'm not sure if it can be. Thoughts @pdpinch @pwilkins?

#### Any background context you want to provide?
 - This PR does not do any validation on the input spreadsheet. If the columns are misnamed (even if the case doesn't match exactly) then they are ignored. If the parsing of the number fails then the two columns are ignored.
 - Also, every row is assumed to have the same `max_pts` and `normalize` value.
 - `normalize` must be `0` or `1`, it cannot be any other truthy value or else it will be ignored.

#### What GIF best describes this PR or how it makes you feel?
![](http://i.imgur.com/ki41AH1.gif)
