### PR TITLE
Remove invalid commas from test_requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 from setuptools.command.test import test as testcommand
 
 with open('test_requirements.txt') as test_reqs:
-    tests_require = test_reqs.readlines(),
+    tests_require = test_reqs.readlines()
 
 
 class PyTest(testcommand):

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,9 +1,9 @@
 pytest-cov>=1.8.0
-pytest-pep8>=1.0.6,
-pytest-flakes>=0.2,
-pytest>=2.6.3,
-pyflakes>=0.8.1,
-pytest-cache>=1.0,
-httpretty>=0.8.3,
+pytest-pep8>=1.0.6
+pytest-flakes>=0.2
+pytest>=2.6.3
+pyflakes>=0.8.1
+pytest-cache>=1.0
+httpretty>=0.8.3
 semantic_version>=2.3.1
 mock>=1.0.1


### PR DESCRIPTION
Fixes installations using the latest `setuptools`.

(cherry picked from commit 33a1dfaa1a8df41d0051abcc642ae16588cc5b85)