### PR TITLE
Add normalize and max_pts cols to non_assignment_fields array

### DIFF
--- a/pylmod/gradebook.py
+++ b/pylmod/gradebook.py
@@ -1064,7 +1064,9 @@ class GradeBook(Base):
         address (for looking up and matching studentId).
 
         These columns are disregarded: ``ID``, ``Username``,
-        ``Full Name``, ``edX email``, ``External email``.
+        ``Full Name``, ``edX email``, ``External email``,
+        as well as the strings passed in ``max_points_column``
+        and ``normalize_column``, if any.
         All other columns are taken as assignments.
 
         If ``email_field`` is specified, then that field name is taken as
@@ -1104,6 +1106,10 @@ class GradeBook(Base):
         non_assignment_fields = [
             'ID', 'Username', 'Full Name', 'edX email', 'External email'
         ]
+        if max_points_column is not None:
+            non_assignment_fields.append(max_points_column)
+        if normalize_column is not None:
+            non_assignment_fields.append(normalize_column)
 
         if email_field is not None:
             non_assignment_fields.append(email_field)

--- a/pylmod/tests/test_gradebook.py
+++ b/pylmod/tests/test_gradebook.py
@@ -1069,3 +1069,11 @@ class TestGradebook(BaseTest):
             self.assertEqual(kwargs['use_max_points_column'], True)
             self.assertEqual(kwargs['max_points_column'], 'max_pts')
             self.assertEqual(kwargs['normalize_column'], 'normalize')
+            self.assertIn(
+                kwargs['max_points_column'],
+                multi_patch.call_args[0][3]
+            )
+            self.assertIn(
+                kwargs['normalize_column'],
+                multi_patch.call_args[0][3]
+            )

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,10 +1,10 @@
 pytest-cov>=1.8.0
-pytest-pep8>=1.0.6,
-pytest-flakes>=0.2,
-pytest>=2.6.3,
-pyflakes>=0.8.1,
-pytest-cache>=1.0,
-httpretty>=0.8.3,
+pytest-pep8>=1.0.6
+pytest-flakes>=0.2
+pytest>=2.6.3
+pyflakes>=0.8.1
+pytest-cache>=1.0
+httpretty>=0.8.3
 semantic_version>=2.3.1
 mock>=1.0.1
 ddt==1.0.1


### PR DESCRIPTION
Pylmod has an array of column names that are ignored as assignment names.  Column names that are not in this array are processed as assignment scores.  This change adds the contents of the ``max_points_column` and ``normalize_column`` parameters to this array.

@pdpinch @bdero