### PR TITLE
Update setup.py for upgraded pytest version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,10 +42,6 @@ class PyTest(testcommand):
         import pytest
         # Needed in order for pytest_cache to load properly
         # Alternate fix: import pytest_cache and pass to pytest.main
-        import _pytest.config
-
-        pm = _pytest.config.get_plugin_manager()
-        pm.consider_setuptools_entrypoints()
         errno = pytest.main(self.test_args)
         sys.exit(errno)
 


### PR DESCRIPTION
Removed call to ``consider_setuptools_entrypoints`` in ``PytestPluginManager`` since that attribute has been removed in current version of ``pytest`` and 
```
python setup.py test
```
failed without this change.
