### PR TITLE
removed empty line from test_requirements.txt

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -8,4 +8,3 @@ httpretty>=0.8.3
 semantic_version>=2.3.1
 mock>=1.0.1
 ddt==1.0.1
-


### PR DESCRIPTION
#### What are the relevant tickets?

fixes #72 
#### What's this PR do?

removes a blank at the end of `test_requirements.txt` which was causing an error when pip installing the library
#### How should this be manually tested?

Try running `python setup.py sdist bdist_wheel` before and after the change
#### Any background context you want to provide?

The bug that this fixes only affects the installation of tests, so it doesn't block (most) current users.
